### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-design.yml
+++ b/.github/workflows/validate-design.yml
@@ -2,6 +2,9 @@ name: Validate AMU Design
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/stellardreams/asi.surge.sh/security/code-scanning/1](https://github.com/stellardreams/asi.surge.sh/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is restricted to least privilege.  
Best fix here: add workflow-level permissions right below `on:` so it applies to all jobs in this workflow (currently only `validate`). For the shown steps, `contents: read` is sufficient: `actions/checkout` needs repo read access, and artifact upload does not require repository write scope. This preserves existing behavior while satisfying CodeQL.

Edit only `.github/workflows/validate-design.yml`:
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it between line 3 (`on: ...`) and line 5 (`jobs:`) in the provided snippet.
- No imports, methods, or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
