### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/token-ci.yml
+++ b/.github/workflows/token-ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/stellardreams/asi.surge.sh/security/code-scanning/2](https://github.com/stellardreams/asi.surge.sh/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/token-ci.yml` at the workflow root (after `on` and before `jobs`) so all jobs inherit least-privilege defaults.  
For this workflow, the minimal required permission is:

- `contents: read`

This preserves existing functionality (checkout, setup-node, npm/hardhat steps, artifact upload) while ensuring `GITHUB_TOKEN` is not over-privileged by default repository/org settings. No imports, methods, or extra definitions are needed—just YAML configuration in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
