### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/token-dashboard.html
+++ b/token-dashboard.html
@@ -256,18 +256,6 @@
                 "event Approval(address indexed owner, address indexed spender, uint256 value)"
             ];
             
-            // Governance contract ABI (simplified)
-            const governanceABI = [
-                "function proposals(uint256) view returns (Proposal memory)",
-                "function nextProposalId() view returns (uint256)",
-                "function createProposal(string memory, uint256) returns (uint256)",
-                "function vote(uint256, bool) returns (bool)",
-                "function executeProposal(uint256)",
-                "event ProposalCreated(uint256 indexed proposalId, address indexed proposer, string description, uint256 targetAmount)",
-                "event VoteCast(address indexed voter, uint256 proposalId, bool support, uint256 amount)",
-                "event ProposalExecuted(uint256 proposalId, bool passed)"
-            ];
-            
             // Connect wallet function
             connectButton.addEventListener('click', async () => {
                 if (typeof window.ethereum !== 'undefined') {


### PR DESCRIPTION
General fix: remove unused variables when they are not part of active logic, or integrate them into real usage if needed. This reduces noise and prevents static analysis warnings.

Best fix here without changing functionality: delete the `governanceABI` constant block (lines 259–269 region) because nothing in the shown code references it. This preserves runtime behavior exactly, since unused declarations do not affect execution.

File/region to change:
- `token-dashboard.html`: remove the governance ABI declaration block immediately below `tokenABI`.

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._