### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/scripts/ipfs-storage.js
+++ b/scripts/ipfs-storage.js
@@ -1,5 +1,4 @@
 const IPFS = require('ipfs');
-const fs = require('fs');
 
 class IPFSBlueprintStorage {
     constructor() {


### PR DESCRIPTION
The correct fix is to remove the unused `fs` import from `scripts/ipfs-storage.js`.

Best single change without altering functionality:
- In `scripts/ipfs-storage.js`, delete line 2 (`const fs = require('fs');`).
- No other code changes are required.
- No new methods, definitions, or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._